### PR TITLE
build: fix exporting manifest lists

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -68,6 +68,7 @@ jobs:
         with:
           context: .
           load: true
+          platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           tags: ${{ steps.meta.outputs.tags }}
           sbom: true
@@ -93,6 +94,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           tags: ${{ steps.meta.outputs.tags }}
           sbom: true


### PR DESCRIPTION
# PR Template

## Description

This PR fixes `ERROR: docker exporter does not currently support exporting manifest lists`

## Related Issues

<!-- Please list any related issues that are being addressed in this pull request. -->
<!-- If does not have related issues type `None` or `No issue` -->

## Checklist

Please review and check off the following items:

- [x] I have tested these changes locally. <!--id:1-->
- [ ] I have added the necessary test cases. <!--id:2-->
- [ ] I have added or updated the documentation to reflect these changes. <!--id:3-->
- [x] I have checked that these changes do not introduce any new warnings or errors. <!--id:4-->
- [x] I have reviewed the code and ensured that it meets our team's coding standards. <!--id:5-->
